### PR TITLE
Fix .gitignore pattern and add main.go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.dll
 *.so
 *.dylib
-qiita-to-csv
+/qiita-to-csv
 
 # Test binary, built with `go test -c`
 *.test
@@ -21,8 +21,10 @@ go.work
 # macOS specific files
 .DS_Store
 
-# CSV data files
+# Output data files
 *.csv
+*.json
+qiita_items_*.md
 
 # IDE specific files
 .idea/

--- a/cmd/qiita-to-csv/main.go
+++ b/cmd/qiita-to-csv/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/umekikazuya/qiita-to-csv/src"
+)
+
+func main() {
+	// コマンドライン引数の処理
+	tokenPtr := flag.String("token", "", "Qiita API access token")
+	outputPtr := flag.String("output", "", "Output CSV file path")
+	flag.Parse()
+
+	token := *tokenPtr
+
+	// 環境変数からトークンを取得（コマンドライン引数がない場合）
+	if token == "" {
+		token = os.Getenv("QIITA_ACCESS_TOKEN")
+		if token == "" {
+			fmt.Println("エラー: Qiitaアクセストークンが必要です。-token オプションまたは QIITA_ACCESS_TOKEN 環境変数で指定してください。")
+			os.Exit(1)
+		}
+	}
+
+	// 出力ファイル名が指定されていない場合は自動生成
+	output := *outputPtr
+	if output == "" {
+		output = fmt.Sprintf("qiita_articles_%s.csv", time.Now().Format("20060102_150405"))
+	}
+
+	// Qiitaクライアントの作成
+	client := src.NewQiitaClient(token)
+
+	// 全ての投稿を取得
+	fmt.Println("Qiitaから投稿データを取得中...")
+	items, err := client.GetAllUserItems()
+	if err != nil {
+		fmt.Printf("エラー: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("%d件の投稿を取得しました\n", len(items))
+
+	// CSVに保存
+	fmt.Printf("CSVファイルに保存中: %s\n", output)
+	if err := src.ItemToCSV(items, output); err != nil {
+		fmt.Printf("エラー: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("完了しました！")
+}


### PR DESCRIPTION
This pull request introduces a new main program for the `qiita-to-csv` tool, which includes handling command-line arguments, retrieving Qiita API tokens, fetching user posts, and saving them to a CSV file.

Key changes:

* Added a new `main.go` file to the `cmd/qiita-to-csv` directory, which includes the main function to run the program.
* Implemented command-line argument parsing for the Qiita API token and output CSV file path.
* Added functionality to retrieve the Qiita API token from environment variables if not provided via command-line arguments.
* Created a Qiita client to fetch all user posts and handle errors appropriately.
* Implemented logic to save the fetched posts to a CSV file, with automatic filename generation if not specified.